### PR TITLE
Implements Lazy ItemStack Capabilities

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -26,7 +26,7 @@
 -   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) {
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) { this(p_i48204_1_, p_i48204_2_, (CompoundNBT) null); }
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_, @Nullable CompoundNBT capNBT) {
-+      super(ItemStack.class);
++      super(ItemStack.class, true);
 +      this.capNBT = capNBT;
        this.field_151002_e = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j();
 +      this.delegate = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j().delegate;
@@ -45,7 +45,7 @@
     }
  
     private ItemStack(CompoundNBT p_i47263_1_) {
-+      super(ItemStack.class);
++      super(ItemStack.class, true);
 +      this.capNBT = p_i47263_1_.func_74764_b("ForgeCaps") ? p_i47263_1_.func_74775_l("ForgeCaps") : null;
 +      Item rawItem =
        this.field_151002_e = Registry.field_212630_s.func_82594_a(new ResourceLocation(p_i47263_1_.func_74779_i("id")));

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -44,6 +44,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
     private boolean isLazy = false;
     private ICapabilityProvider lazyParent = null;
     private CompoundNBT lazyData = null;
+    private boolean initialized = false;
 
     protected CapabilityProvider(Class<B> baseClass)
     {
@@ -60,7 +61,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final void gatherCapabilities(@Nullable ICapabilityProvider parent)
     {
-        if (isLazy) {
+        if (isLazy && !initialized) {
             lazyParent = parent;
             return;
         }
@@ -70,11 +71,12 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     private void doGatherCapabilities(@Nullable ICapabilityProvider parent) {
         this.capabilities = ForgeEventFactory.gatherCapabilities(baseClass, this, parent);
+        this.initialized = true;
     }
 
     protected final @Nullable CapabilityDispatcher getCapabilities()
     {
-        if(isLazy) {
+        if(isLazy && !initialized) {
             doGatherCapabilities(lazyParent);
             if (lazyData != null) {
                 deserializeCaps(lazyData);
@@ -121,7 +123,7 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     protected final void deserializeCaps(CompoundNBT tag)
     {
-        if (isLazy) {
+        if (isLazy && !initialized) {
             lazyData = tag;
             return;
         }

--- a/src/test/java/net/minecraftforge/common/capabilities/LazyCapabilitiesOnItemsTest.java
+++ b/src/test/java/net/minecraftforge/common/capabilities/LazyCapabilitiesOnItemsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.common.util.NonNullLazy;
+import net.minecraftforge.common.util.TablePrinter;
+import net.minecraftforge.common.util.TextTable;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStackSimple;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static net.minecraftforge.common.util.TextTable.column;
+
+@Mod(LazyCapabilitiesOnItemsTest.MOD_ID)
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = LazyCapabilitiesOnItemsTest.MOD_ID)
+public class LazyCapabilitiesOnItemsTest
+{
+    public static final String MOD_ID = "lazy_capabilities_on_items";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final boolean ENABLED = true;
+    private static final int SAMPLE_SIZE = 100000;
+    
+    public LazyCapabilitiesOnItemsTest()
+    {
+        if (!ENABLED)
+            return;
+
+        final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        modBus.addListener(this::onCommonSetup);
+    }
+
+    private void onCommonSetup(FMLCommonSetupEvent event)
+    {
+        CapabilityProvider.SUPPORTS_LAZY_CAPABILITIES = false;
+
+        final Stopwatch timer = Stopwatch.createUnstarted();
+        final IEventBus bus = MinecraftForge.EVENT_BUS;
+
+        final ResourceLocation testCapId = new ResourceLocation(MOD_ID, "test");
+        final Consumer<AttachCapabilitiesEvent<ItemStack>> capAttachmentHandler = e -> {
+            //Example capability we make everything a bucket :D
+            e.addCapability(testCapId, new FluidHandlerItemStackSimple(e.getObject(), SAMPLE_SIZE));
+        };
+
+        ///First test: SAMPLE_SIZE itemstacks which do not have a capability attached.
+        timer.start();
+        for (int i = 0; i < SAMPLE_SIZE; i++)
+        {
+            final ItemStack stack = new ItemStack(Items.OAK_LOG);
+        }
+        timer.stop();
+
+        final long simpleNoCapsLazyDisabledElapsed = timer.elapsed(TimeUnit.MICROSECONDS);
+        timer.reset();
+
+        ///Second test: SAMPLE_SIZE itemstacks with a capability attached.
+        bus.addGenericListener(ItemStack.class, capAttachmentHandler);
+        timer.start();
+        for (int i = 0; i < SAMPLE_SIZE; i++)
+        {
+            final ItemStack stack = new ItemStack(Items.OAK_LOG);
+        }
+        timer.stop();
+
+        final long withCapsLazyDisabledElapsed = timer.elapsed(TimeUnit.MICROSECONDS);
+        timer.reset();
+        bus.unregister(capAttachmentHandler);
+
+        ///Third test: SAMPLE_SIZE itemstacks which do not have a capability attached.
+        CapabilityProvider.SUPPORTS_LAZY_CAPABILITIES = true;
+        timer.start();
+        for (int i = 0; i < SAMPLE_SIZE; i++)
+        {
+            final ItemStack stack = new ItemStack(Items.OAK_LOG);
+        }
+        timer.stop();
+
+        final long simpleNoCapsLazyEnabledElapsed = timer.elapsed(TimeUnit.MICROSECONDS);
+        timer.reset();
+
+        ///Fourth test: SAMPLE_SIZE itemstacks with a capability attached.
+        bus.addGenericListener(ItemStack.class, capAttachmentHandler);
+        timer.start();
+        for (int i = 0; i < SAMPLE_SIZE; i++)
+        {
+            final ItemStack stack = new ItemStack(Items.OAK_LOG);
+        }
+        timer.stop();
+
+        final long withCapsLazyEnabledElapsed = timer.elapsed(TimeUnit.MICROSECONDS);
+        timer.reset();
+        bus.unregister(capAttachmentHandler);
+
+        TextTable table = new TextTable(Lists.newArrayList(
+          column("Test type", TextTable.Alignment.LEFT),
+          column("Total time", TextTable.Alignment.CENTER)
+        ));
+
+        table.add("Lazy: Disabled / Caps: None", simpleNoCapsLazyDisabledElapsed + " ms.");
+        table.add("Lazy: Disabled / Caps: One", withCapsLazyDisabledElapsed + " ms.");
+        table.add("Lazy: Enabled  / Caps: None", simpleNoCapsLazyEnabledElapsed + " ms.");
+        table.add("Lazy: Enabled  / Caps: One", withCapsLazyEnabledElapsed + " ms.");
+
+        final String[] resultData = table.build("\n").split("\n");
+        for (final String line : resultData)
+        {
+            LOGGER.warn(line);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -138,3 +138,5 @@ license="LGPL v2.1"
     modId="dimension_settings_test"
 [[mods]]
     modId="player_attack_knockback_test"
+[[mods]]
+    modId="lazy_capabilities_on_items"


### PR DESCRIPTION
#### General:
Picks up where the original author of: #7830 left of.

Simple support for lazy capabilities by delaying the call to `ForgeEventFactory.gatherCapabilities(baseClass, this, parent);` to the first moment when `CapabilityDispatcher getCapabilities()` is called.

In the meanwhile this caches both the parent dispatcher and the potential cap data.

#### Test result data:
| Test type                   | Total time |
|:--------------------------- |:----------:|
| Lazy: Disabled / Caps: None | 14641 ms.  |
| Lazy: Disabled / Caps: One  | 10658 ms.  |
| Lazy: Enabled  / Caps: None |  7672 ms.  |
| Lazy: Enabled  / Caps: One  |  6376 ms.  |
